### PR TITLE
Added a showLeaderboardwithCategory

### DIFF
--- a/DDGameKitHelper.h
+++ b/DDGameKitHelper.h
@@ -45,6 +45,7 @@
 
 -(void) showLeaderboard;
 
+-(void) showLeaderboardwithCategory:(NSString*)category timeScope:(int)tscope;
 
 -(void) showAchievements;
 

--- a/DDGameKitHelper.h
+++ b/DDGameKitHelper.h
@@ -45,6 +45,7 @@
 
 -(void) showLeaderboard;
 
+
 -(void) showAchievements;
 
 -(GKAchievementDescription*) getAchievementDescription:(NSString*)identifier;

--- a/DDGameKitHelper.m
+++ b/DDGameKitHelper.m
@@ -536,6 +536,27 @@ static DDGameKitHelper *instanceOfGameKitHelper;
     }
 }
 
+-(void) showLeaderboardwithCategory:(NSString*)category timeScope:(int)tscope 
+{
+    if (isGameCenterAvailable == NO)
+    {
+        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Game Center" message:@"Game Center is not available" delegate:nil cancelButtonTitle:@"OK" otherButtonTitles: nil, nil];
+        [alert show];
+        [alert release];
+        
+        return;
+    }
+    
+    GKLeaderboardViewController* leaderboardVC = [[[GKLeaderboardViewController alloc] init] autorelease];
+    if (leaderboardVC != nil)
+    {
+        leaderboardVC.leaderboardDelegate = self;
+        leaderboardVC.category = category;
+        leaderboardVC.timeScope = tscope;
+        [self presentViewController:leaderboardVC];
+    }  
+}
+
 -(void) leaderboardViewControllerDidFinish:(GKLeaderboardViewController*)viewController
 {
     [self dismissModalViewController];

--- a/README
+++ b/README
@@ -1,4 +1,14 @@
-DESCRIPTION
+- Ive just added an additional method to allow you to select which leaderboard and timescale you want to show.
+
+Use it like so:
+
+[[DDGameKitHelper sharedGameKitHelper] showLeaderboardwithCategory:@"LeaderboardID" timeScope:GKLeaderboardTimeScopeAllTime];
+
+where GKLeaderboardTimeScopeAllTime is also available in GKLeaderboardTimeScopeToday and GKLeaderboardTimeScopeWeek
+
+
+
+DESCRIPTION from csddavies
 
 A simpler GameKitHelper inspired by Steffen Itterheim's version
 (http://www.learn-cocos2d.com). This version takes a different approach
@@ -38,7 +48,6 @@ https://github.com/typeoneerror/GKAchievementNotification
 It does an excellent job of display a slide down notification that fits in
 seamlessly with game center. The only thing I needed to add to it was an
 adjustFrame method to compensate for the iPad.
-
 
 USING IT
 


### PR DESCRIPTION
User can now show the default lb with your method, or use mine to pass through category and timescope.

Category is just the leaderboardID, and timeScope is one of the int's below (as Im sure you know...)

GKLeaderboardTimeScopeAllTime
GKLeaderboardTimeScopeToday
GKLeaderboardTimeScopeWeek

Fully tested and working perfectly fine for me. Thanks for the helper!
