### PR TITLE
Fixed crash due to empty `playerScores` array in iOS 4.1

### DIFF
--- a/DDGameKitHelper.m
+++ b/DDGameKitHelper.m
@@ -292,7 +292,7 @@ static DDGameKitHelper *instanceOfGameKitHelper;
                   }
                   
                   GKScore* gcScore = nil;
-                  if (playerScores != nil)
+                  if ([playerScores count] > 0)
                       gcScore = [playerScores objectAtIndex:0];
                   GKScore* localScore = [scores objectForKey:category];
                   


### PR DESCRIPTION
I've found an issue in a live application. Users with iOS 4.1 experience crashes with the following logs:

```
*** -[NSMutableArray objectAtIndex:]: index 0 beyond bounds for empty array

CoreFoundation 0x30897ec1 __exceptionPreprocess 96
1 libobjc.A.dylib 0x3002f811 objc_exception_throw 24
2 CoreFoundation 0x30829d79 -[__NSArrayM objectAtIndex:] 184
3 MyApp 0x0003412d __block_global_0 (in MyApp) (DDGameKitHelper.m:294)
4 GameKit 0x3514dcb3 __-[GKLeaderboard loadScoresForGame:withCompletionHandler:]_block_invoke_1 658
5 GameKit 0x3516b49f __-[GKDataRequest handleResponseFromServer:error:]_block_invoke_1 34
6 libSystem.B.dylib 0x302d4984 _dispatch_call_block_and_release 20
7 libSystem.B.dylib 0x302d59fc _dispatch_main_queue_callback_4CF 220
8 CoreFoundation 0x3081f89b __CFRunLoopRun 1334
...
```

So it's crashing on a line:

```
gcScore = [playerScores objectAtIndex:0];
```

I have no ability to reproduct this issue, but the I suppose my fix should be enough.
