### PR TITLE
Added isLocalPlayerAuthenticated method.

### DIFF
--- a/DDGameKitHelper.h
+++ b/DDGameKitHelper.h
@@ -37,6 +37,8 @@
 
 -(void) authenticateLocalPlayer;
 
+-(bool) isLocalPlayerAuthenticated;
+
 -(void) submitScore:(int64_t)value category:(NSString*)category;
 
 -(void) reportAchievement:(NSString*)identifier percentComplete:(float)percent;

--- a/DDGameKitHelper.m
+++ b/DDGameKitHelper.m
@@ -154,6 +154,15 @@ static DDGameKitHelper *instanceOfGameKitHelper;
     }
 }
 
+-(bool) isLocalPlayerAuthenticated
+{
+	if (isGameCenterAvailable == NO)
+		return isGameCenterAvailable;
+
+	GKLocalPlayer* localPlayer = [GKLocalPlayer localPlayer];
+	return localPlayer.authenticated;
+}
+
 -(void) onLocalPlayerAuthenticationChanged
 {
     NSString* newPlayerID;

--- a/README
+++ b/README
@@ -44,6 +44,11 @@ Authenticating a player
 
 [[DDGameKitHelper sharedGameKitHelper] authenticateLocalPlayer];
 
+Checking authentication
+-----------------------
+
+[[DDGameKitHelper sharedGameKitHelper] isLocalPlayerAuthenticated];
+
 Unlocking an achievement 
 ------------------------
 


### PR DESCRIPTION
Convenience method to check if the local player is authenticated or not.  Safe to call if Game Center is not available: returns NO if Game Center is not available.

Keeps one from having to muck around with GKLocalPlayer directly.
